### PR TITLE
add: lookup type 'not_in'

### DIFF
--- a/lookupy/lookupy.py
+++ b/lookupy/lookupy.py
@@ -151,6 +151,9 @@ def lookup(key, val, item):
     elif last == 'in':
         val = guard_iter(val)
         return dunder_get(item, init) in val
+    elif last == 'not_in':
+        val = guard_iter(val)
+        return dunder_get(item, init) not in val
     elif last == 'startswith':
         val = guard_str(val)
         return iff_not_none(dunder_get(item, init), lambda y: y.startswith(val))

--- a/lookupy/tests.py
+++ b/lookupy/tests.py
@@ -108,6 +108,7 @@ def test_lookup():
     # in          -- works for strings and lists, else raises error
     assert lookup('request__url__in', ['http://example.com',
                                        'http://blog.example.com'], entry1)
+    assert lookup('request__url__not_in', ['http://example.io'], entry1)
 
     assert lookup('response__status__in', [400, 200], entry2)
     assert not lookup('response__status__in', [], entry2)


### PR DESCRIPTION
We use lookupy with various microservices, that depend on keyword filtering. There is a membership lookup 'in', but if we want to do the opposite, we have only the option to invert the Q object, which is not JSON serializable